### PR TITLE
backend-dnf.c: improve package counting

### DIFF
--- a/src/backend-dnf.c
+++ b/src/backend-dnf.c
@@ -25,6 +25,34 @@
 #include "../config.h"
 #include "applet.h"
 
+static int is_update_package(const char *line) {
+	int state = 0;
+
+	// Check if line is a package to update.
+	// Such lines have the form '^\S+\.\S+[ \t]'.
+
+	for (;;) {
+		switch (*line++) {
+		case ' ':
+		case '\t':
+			return state == 03;
+		case '\0':
+		case '\r':
+		case '\n':
+			return 0;
+		case '.':
+			if (!(state & 01))
+				return 0;
+			state = 02;
+			break;
+		default:
+			state |= 01;
+			break;
+		}
+	}
+}
+
+
 void dnf_main (softupd_applet *applet) {
 	int pipefd[2];
 	pipe(pipefd);
@@ -33,7 +61,7 @@ void dnf_main (softupd_applet *applet) {
 	
 	// CHILD
 	if (pid == 0) {
-		// If there are aupdates, dnf will return with exit code 100
+		// If there are updates, dnf will return with exit code 100
 		// and print the updates on stdout, one per line. 
 		// We need to count them.
                 close(pipefd[0]);
@@ -48,13 +76,14 @@ void dnf_main (softupd_applet *applet) {
 	else {
 		int status;
 		char line[1024];
-		// Count the lines, skipping the first which dnf always prints.
-		int line_cnt = -1;
+		// Count the lines matching an update package.
+		int line_cnt = 0;
 
 		close(pipefd[1]);
 		FILE *fp = fdopen(pipefd[0], "r");
 		while (fgets(&line[0], 1024, fp)) {
-			line_cnt++;
+			if (is_update_package(line))
+				line_cnt++;
 		}
 
 		waitpid(pid, &status, 0);


### PR DESCRIPTION
Hi Assen,
As promised in my previous PR, here is a fix on dnf backend package counting.

Some dnf output lines do not contain an update package name, causing a
simple line count to be inaccurate.
This adds a pattern test on each line, checking if it shows an update
package or not: only matching lines are then counted.

Cheers,
Patrick