### PR TITLE
Fix issue where applet fails to notice any updates after initial check.

### DIFF
--- a/src/applet.h
+++ b/src/applet.h
@@ -56,9 +56,8 @@ typedef struct {
 } softupd_applet;
 
 // Prototypes
-gboolean packagekit_main();
-int yumupdatesd_main();
-void yum_main();
-void aptcheck_main();
-void aptget_main();
-void dnf_main();
+gboolean packagekit_main(softupd_applet *);
+gboolean yumupdatesd_main(softupd_applet *);
+gboolean yum_main(softupd_applet *);
+gboolean aptcheck_main(softupd_applet *);
+gboolean dnf_main(softupd_applet *);

--- a/src/backend-aptcheck.c
+++ b/src/backend-aptcheck.c
@@ -26,7 +26,7 @@
 #include "../config.h"
 #include "applet.h"
 
-void aptcheck_main (softupd_applet *applet) {
+gboolean aptcheck_main (softupd_applet *applet) {
 	int pipefd[2];
 	pipe(pipefd);
 
@@ -68,5 +68,6 @@ void aptcheck_main (softupd_applet *applet) {
                         applet->flip_icon = 1;
 
 	}
+        return TRUE;
 }
 

--- a/src/backend-dnf.c
+++ b/src/backend-dnf.c
@@ -25,7 +25,7 @@
 #include "../config.h"
 #include "applet.h"
 
-void dnf_main (softupd_applet *applet) {
+gboolean dnf_main (softupd_applet *applet) {
 	int pipefd[2];
 	pipe(pipefd);
 
@@ -79,5 +79,6 @@ void dnf_main (softupd_applet *applet) {
         	        applet->flip_icon = 1;
 
 	}
+        return TRUE;
 }
 

--- a/src/backend-yum.c
+++ b/src/backend-yum.c
@@ -25,7 +25,7 @@
 #include "../config.h"
 #include "applet.h"
 
-void yum_main (softupd_applet *applet) {
+gboolean yum_main (softupd_applet *applet) {
 	int pipefd[2];
 	pipe(pipefd);
 
@@ -79,5 +79,6 @@ void yum_main (softupd_applet *applet) {
         	        applet->flip_icon = 1;
 
 	}
+        return TRUE;
 }
 

--- a/src/backend-yumupdatesd.c
+++ b/src/backend-yumupdatesd.c
@@ -59,7 +59,7 @@ static DBusHandlerResult signal_filter (DBusConnection *connection, DBusMessage 
 	return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
 }
 
-int yumupdatesd_main (softupd_applet *applet){
+gboolean yumupdatesd_main (softupd_applet *applet){
         DBusConnection *bus;
         DBusError error;
 
@@ -81,6 +81,6 @@ int yumupdatesd_main (softupd_applet *applet){
 
         g_main_loop_run(applet->loop);
 
-        return 1;
+        return TRUE;
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -280,16 +280,6 @@ static gboolean applet_listener(softupd_applet *applet) {
 		return TRUE;
 	#endif
 
-	#ifdef HAVE_APTGET
-		#ifdef HAVE_GTK2
-		g_timeout_add(REFRESH_TIME, (GtkFunction) aptget_main, (gpointer)applet);
-		#elif HAVE_GTK3
-		g_timeout_add(REFRESH_TIME, (GSourceFunc) aptget_main, (gpointer)applet);
-		#endif
-		applet->loop = g_main_loop_new (NULL, FALSE);
-		g_main_loop_run (applet->loop);
-		return TRUE;
-	#endif
 }
 
 


### PR DESCRIPTION
I noticed that the applet wasn't reporting any updates being available despite 'dnf check-update' reporting that there was. Turns out that dnf_main() is returning void whereas g_timeout_add() is expecting it to return a gboolean. I guess the compiler is leaving a zero value in the EAX register which mean that dnf_main only gets called once.
This commit fixes this and any other similarly affected backend.