### PR TITLE
* Don't leak a pipe file descriptor each time the backend is called.

### DIFF
--- a/src/backend-dnf.c
+++ b/src/backend-dnf.c
@@ -54,12 +54,21 @@ static int is_update_package(const char *line) {
 
 gboolean dnf_main (softupd_applet *applet) {
 	int pipefd[2];
-	pipe(pipefd);
+	if (pipe(pipefd) == -1) {
+		applet->pending = -1;
+		return TRUE;
+	}
 
 	int pid = fork();
-	
+
+	if (pid == -1) {
+		close(pipefd[0]);
+		close(pipefd[1]);
+		applet->pending = -1;
+	}
+
 	// CHILD
-	if (pid == 0) {
+	else if (pid == 0) {
 		// If there are updates, dnf will return with exit code 100
 		// and print the updates on stdout, one per line. 
 		// We need to count them.
@@ -69,6 +78,7 @@ gboolean dnf_main (softupd_applet *applet) {
                 close(pipefd[1]);
 
 		execlp(DNF_BINARY, DNF_BINARY, "check-update", (char *)NULL);
+		abort();
 	}
 
 	// PARENT
@@ -80,13 +90,19 @@ gboolean dnf_main (softupd_applet *applet) {
 
 		close(pipefd[1]);
 		FILE *fp = fdopen(pipefd[0], "r");
+		if (fp == NULL) {
+			close(pipefd[0]);
+			applet->pending = -1;
+			return TRUE;
+		}
 		while (fgets(&line[0], 1024, fp)) {
 			if (is_update_package(line))
 				line_cnt++;
 		}
 
 		waitpid(pid, &status, 0);
-		int exit_status = WEXITSTATUS(status);
+		fclose(fp);
+		int exit_status = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
 
 		if (exit_status == 0) 
 			applet->pending = 0;


### PR DESCRIPTION
  This prevents the applet segfaulting every Friday once the ulimit
  is reached.
* Generally improve error handling around backend launching.
* If the backend did fail, the applet shouldn't claim there are four
  billion updates to install.